### PR TITLE
Feature to set cpu limit for container and Fixes container logging and exit

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -5,4 +5,5 @@ const (
 	DockerDefaultProtocolAndPort = "8080/tcp"
 	GoDefaultExecutableName      = "app"
 	DockerContainerMemoryLimit   = 2.147e+9
+	ContainerLogsDirectory       = "./logs"
 )

--- a/deploy/dockerApi.go
+++ b/deploy/dockerApi.go
@@ -166,6 +166,10 @@ func setContainerResources(deployRequest models.DeployRequest) *container.Resour
 		resources.Memory = constants.DockerContainerMemoryLimit
 	}
 
+	if deployRequest.CPUs != nil {
+		resources.NanoCPUs = int64(*deployRequest.CPUs * float64(1e+9))
+	}
+
 	return &resources
 }
 

--- a/models/types.go
+++ b/models/types.go
@@ -14,4 +14,5 @@ type DeployRequest struct {
 	Branch        string   `json:"branch"`
 	MemoryLimit   *int64   `json:"memoryLimit"`
 	Mounts        *[]Mount `json:"mounts"`
+	CPUs          *float64 `json:"cpus"`
 }


### PR DESCRIPTION
#### _CPU LIMIT_ : 
Since Docker API expects NanoCPUs (CPU quota in units of 10<sup>-9</sup> CPUs) to be provided, we will accept float value of CPU limit which will be converted to NanoCPUs.

For e.g. 
Post request with following
```
  "cpus": 1.32
```
Will result in Container having 1320000000 NanoCPUs.